### PR TITLE
Add missing alt attributes to image elements

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -13,7 +13,7 @@ const Avatar = ({ src, height = 45, text }) => {
         src={src}
         height={height}
         width={height}
-        alt="avatar"
+        alt="Avatar"
       />
       {text}
     </span>

--- a/src/pages/property/PropertyDetail.js
+++ b/src/pages/property/PropertyDetail.js
@@ -153,8 +153,8 @@ const PropertyDetail = (props) => {
           </Container>
 
           {/* Image */}
-          <Card style={{}}>
-            <Card.Img src={image} variant="top" />
+          <Card>
+            <Card.Img src={image} variant="top" alt="Property image" />
 
             {/* User Profile */}
             <Card.Body className="d-flex flex-sm-row justify-content-between align-items-center">
@@ -311,9 +311,9 @@ const PropertyDetail = (props) => {
           <div>{is_owner && propertyPage && "..."}</div>
 
           {/* Image */}
-          <Card style={{}}>
+          <Card>
             <Link to={`/property/${id}`}>
-              <Card.Img src={image} variant="top" />
+              <Card.Img src={image} variant="top" alt="Property image" />
             </Link>
 
             {/* User Profile */}


### PR DESCRIPTION
- Missing alt attributes brought to the developers attention via the Lighthouse tool
- Searched the app for img elements and filled in the alt attributes with appropriate tags